### PR TITLE
Make this crate into a library as well.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,15 @@ repository = "https://github.com/ksceriath/json-diff"
 keywords = ["cli", "diff", "json"]
 categories = ["command-line-utilities"]
 
+[lib]
+name = "json_diff"
+path = "src/lib.rs"
+crate-type = ["lib"]
+
+[[bin]]
+name = "json_diff"
+path = "src/main.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use colored::*;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Message {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,8 @@
 use colored::*;
 use std::fmt;
 
-#[derive(Debug)]
+// PartialEq is added for the sake of Test case that uses assert_eq
+#[derive(Debug, PartialEq)]
 pub enum Message {
     BadOption,
     SOURCE1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,196 @@
+pub mod constants;
+pub mod ds;
+mod process;
+
+use colored::*;
+use constants::Message;
+use ds::{key_node::KeyNode, mismatch::Mismatch};
+use std::io::{self, Write};
+
+pub fn compare_jsons(a: &str, b: &str) -> Result<Mismatch, serde_json::Error> {
+    let value1 = serde_json::from_str(a)?;
+    let value2 = serde_json::from_str(b)?;
+    Ok(process::match_json(&value1, &value2))
+}
+
+pub fn display_output(result: Mismatch) -> Result<(), std::io::Error> {
+    let no_mismatch = Mismatch {
+        left_only_keys: KeyNode::Nil,
+        right_only_keys: KeyNode::Nil,
+        keys_in_both: KeyNode::Nil,
+    };
+
+    let stdout = io::stdout();
+    let mut handle = io::BufWriter::new(stdout.lock());
+    Ok(if no_mismatch == result {
+        writeln!(handle, "\n{}", Message::NoMismatch)?;
+    } else {
+        match result.keys_in_both {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.keys_in_both.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::Mismatch)?;
+                for key in keys {
+                    writeln!(handle, "{}", key)?;
+                }
+            }
+            KeyNode::Value(_, _) => writeln!(handle, "{}", Message::RootMismatch)?,
+            KeyNode::Nil => (),
+        }
+        match result.left_only_keys {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.left_only_keys.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::LeftExtra)?;
+                for key in keys {
+                    writeln!(handle, "{}", key.red().bold())?;
+                }
+            }
+            KeyNode::Value(_, _) => (),
+            KeyNode::Nil => (),
+        }
+        match result.right_only_keys {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.right_only_keys.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::RightExtra)?;
+                for key in keys {
+                    writeln!(handle, "{}", key.green().bold())?;
+                }
+            }
+            KeyNode::Value(_, _) => (),
+            KeyNode::Nil => (),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use maplit::hashmap;
+    use serde_json::json;
+
+    #[test]
+    fn nested_diff() {
+        let data1 = r#"{
+            "a":"b", 
+            "b":{
+                "c":{
+                    "d":true,
+                    "e":5,
+                    "f":9,
+                    "h":{
+                        "i":true,
+                        "j":false
+                    }
+                }
+            }
+        }"#;
+        let data2 = r#"{
+            "a":"b",
+            "b":{
+                "c":{
+                    "d":true,
+                    "e":6,
+                    "g":0,
+                    "h":{
+                        "i":false,
+                        "k":false
+                    }
+                }
+            }
+        }"#;
+
+        let expected_left = KeyNode::Node(hashmap! {
+        "b".to_string() => KeyNode::Node(hashmap! {
+                "c".to_string() => KeyNode::Node(hashmap! {
+                        "f".to_string() => KeyNode::Nil,
+                        "h".to_string() => KeyNode::Node( hashmap! {
+                                "j".to_string() => KeyNode::Nil,
+                            }
+                        ),
+                }
+                ),
+            }),
+        });
+        let expected_right = KeyNode::Node(hashmap! {
+            "b".to_string() => KeyNode::Node(hashmap! {
+                    "c".to_string() => KeyNode::Node(hashmap! {
+                            "g".to_string() => KeyNode::Nil,
+                            "h".to_string() => KeyNode::Node(hashmap! {
+                                    "k".to_string() => KeyNode::Nil,
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        });
+        let expected_uneq = KeyNode::Node(hashmap! {
+            "b".to_string() => KeyNode::Node(hashmap! {
+                    "c".to_string() => KeyNode::Node(hashmap! {
+                            "e".to_string() => KeyNode::Value(json!(5), json!(6)),
+                            "h".to_string() => KeyNode::Node(hashmap! {
+                                    "i".to_string() => KeyNode::Value(json!(true), json!(false)),
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        });
+        let expected = Mismatch::new(expected_left, expected_right, expected_uneq);
+
+        let mismatch = compare_jsons(data1, data2).unwrap();
+        assert_eq!(mismatch, expected, "Diff was incorrect.");
+    }
+
+    #[test]
+    fn no_diff() {
+        let data1 = r#"{
+            "a":"b", 
+            "b":{
+                "c":{
+                    "d":true,
+                    "e":5,
+                    "f":9,
+                    "h":{
+                        "i":true,
+                        "j":false
+                    }
+                }
+            }
+        }"#;
+        let data2 = r#"{
+            "a":"b", 
+            "b":{
+                "c":{
+                    "d":true,
+                    "e":5,
+                    "f":9,
+                    "h":{
+                        "i":true,
+                        "j":false
+                    }
+                }
+            }
+        }"#;
+
+        assert_eq!(
+            compare_jsons(data1, data2).unwrap(),
+            Mismatch::new(KeyNode::Nil, KeyNode::Nil, KeyNode::Nil)
+        );
+    }
+
+    #[test]
+    fn no_json() {
+        let data1 = r#"{}"#;
+        let data2 = r#"{}"#;
+
+        assert_eq!(
+            compare_jsons(data1, data2).unwrap(),
+            Mismatch::new(KeyNode::Nil, KeyNode::Nil, KeyNode::Nil)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,10 @@ pub fn compare_jsons(a: &str, b: &str) -> Result<Mismatch, Message> {
     Ok(process::match_json(&value1, &value2))
 }
 
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::ds::{key_node::KeyNode, mismatch::Mismatch};
+    use super::*;
     use maplit::hashmap;
     use serde_json::json;
 
@@ -155,7 +154,7 @@ mod tests {
             Ok(_) => panic!("This shouldn't be an Ok"),
             Err(err) => {
                 assert_eq!(Message::JSON1, err);
-            },
+            }
         };
     }
 
@@ -167,7 +166,7 @@ mod tests {
             Ok(_) => panic!("This shouldn't be an Ok"),
             Err(err) => {
                 assert_eq!(Message::JSON2, err);
-            },
+            }
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,72 +2,18 @@ pub mod constants;
 pub mod ds;
 mod process;
 
-use colored::*;
-use constants::Message;
-use ds::{key_node::KeyNode, mismatch::Mismatch};
-use std::io::{self, Write};
-
+use ds::mismatch::Mismatch;
 pub fn compare_jsons(a: &str, b: &str) -> Result<Mismatch, serde_json::Error> {
     let value1 = serde_json::from_str(a)?;
     let value2 = serde_json::from_str(b)?;
     Ok(process::match_json(&value1, &value2))
 }
 
-pub fn display_output(result: Mismatch) -> Result<(), std::io::Error> {
-    let no_mismatch = Mismatch {
-        left_only_keys: KeyNode::Nil,
-        right_only_keys: KeyNode::Nil,
-        keys_in_both: KeyNode::Nil,
-    };
-
-    let stdout = io::stdout();
-    let mut handle = io::BufWriter::new(stdout.lock());
-    Ok(if no_mismatch == result {
-        writeln!(handle, "\n{}", Message::NoMismatch)?;
-    } else {
-        match result.keys_in_both {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.keys_in_both.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::Mismatch)?;
-                for key in keys {
-                    writeln!(handle, "{}", key)?;
-                }
-            }
-            KeyNode::Value(_, _) => writeln!(handle, "{}", Message::RootMismatch)?,
-            KeyNode::Nil => (),
-        }
-        match result.left_only_keys {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.left_only_keys.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::LeftExtra)?;
-                for key in keys {
-                    writeln!(handle, "{}", key.red().bold())?;
-                }
-            }
-            KeyNode::Value(_, _) => (),
-            KeyNode::Nil => (),
-        }
-        match result.right_only_keys {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.right_only_keys.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::RightExtra)?;
-                for key in keys {
-                    writeln!(handle, "{}", key.green().bold())?;
-                }
-            }
-            KeyNode::Value(_, _) => (),
-            KeyNode::Nil => (),
-        }
-    })
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use super::ds::{key_node::KeyNode, mismatch::Mismatch};
     use maplit::hashmap;
     use serde_json::json;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,15 @@
-use json_diff::{compare_jsons, constants::Message, display_output};
-use std::{fmt, fs, process as proc, str::FromStr};
+use colored::*;
+use json_diff::{
+    compare_jsons,
+    constants::Message,
+    ds::{key_node::KeyNode, mismatch::Mismatch},
+};
+use std::{
+    fmt, fs,
+    io::{self, Write},
+    process as proc,
+    str::FromStr,
+};
 use structopt::StructOpt;
 
 const HELP: &str = r#"
@@ -79,4 +89,55 @@ fn main() {
 fn error_exit(message: Message) -> ! {
     eprintln!("{}", message);
     proc::exit(1);
+}
+
+pub fn display_output(result: Mismatch) -> Result<(), std::io::Error> {
+    let no_mismatch = Mismatch {
+        left_only_keys: KeyNode::Nil,
+        right_only_keys: KeyNode::Nil,
+        keys_in_both: KeyNode::Nil,
+    };
+
+    let stdout = io::stdout();
+    let mut handle = io::BufWriter::new(stdout.lock());
+    Ok(if no_mismatch == result {
+        writeln!(handle, "\n{}", Message::NoMismatch)?;
+    } else {
+        match result.keys_in_both {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.keys_in_both.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::Mismatch)?;
+                for key in keys {
+                    writeln!(handle, "{}", key)?;
+                }
+            }
+            KeyNode::Value(_, _) => writeln!(handle, "{}", Message::RootMismatch)?,
+            KeyNode::Nil => (),
+        }
+        match result.left_only_keys {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.left_only_keys.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::LeftExtra)?;
+                for key in keys {
+                    writeln!(handle, "{}", key.red().bold())?;
+                }
+            }
+            KeyNode::Value(_, _) => (),
+            KeyNode::Nil => (),
+        }
+        match result.right_only_keys {
+            KeyNode::Node(_) => {
+                let mut keys = Vec::new();
+                result.right_only_keys.absolute_keys(&mut keys, None);
+                writeln!(handle, "\n{}:", Message::RightExtra)?;
+                for key in keys {
+                    writeln!(handle, "{}", key.green().bold())?;
+                }
+            }
+            KeyNode::Value(_, _) => (),
+            KeyNode::Nil => (),
+        }
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,5 @@
-mod constants;
-mod ds;
-mod process;
-
-use colored::*;
-use constants::Message;
-use ds::{key_node::KeyNode, mismatch::Mismatch};
-use serde_json;
-use std::{
-    fmt, fs,
-    io::{self, Write},
-    process as proc,
-    str::FromStr,
-};
+use json_diff::{compare_jsons, constants::Message, display_output};
+use std::{fmt, fs, process as proc, str::FromStr};
 use structopt::StructOpt;
 
 const HELP: &str = r#"
@@ -58,11 +46,6 @@ struct Cli {
     source2: String,
 }
 
-fn error_exit(message: constants::Message) -> ! {
-    eprintln!("{}", message);
-    proc::exit(1);
-}
-
 fn main() {
     let args = Cli::from_args();
 
@@ -80,198 +63,20 @@ fn main() {
             }
         }
     };
-    display_output(compare_jsons(&data1, &data2));
-}
-
-fn display_output(result: Mismatch) {
-    let no_mismatch = Mismatch {
-        left_only_keys: KeyNode::Nil,
-        right_only_keys: KeyNode::Nil,
-        keys_in_both: KeyNode::Nil,
+    let mismatch = match compare_jsons(&data1, &data2) {
+        Ok(mismatch) => mismatch,
+        Err(err) => {
+            eprintln!("{}", err);
+            proc::exit(1)
+        }
     };
-
-    let stdout = io::stdout();
-    let mut handle = io::BufWriter::new(stdout.lock());
-    if no_mismatch == result {
-        writeln!(handle, "\n{}", Message::NoMismatch).unwrap();
-    } else {
-        match result.keys_in_both {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.keys_in_both.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::Mismatch).unwrap();
-                for key in keys {
-                    writeln!(handle, "{}", key).unwrap();
-                }
-            }
-            KeyNode::Value(_, _) => writeln!(handle, "{}", Message::RootMismatch).unwrap(),
-            KeyNode::Nil => (),
-        }
-        match result.left_only_keys {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.left_only_keys.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::LeftExtra).unwrap();
-                for key in keys {
-                    writeln!(handle, "{}", key.red().bold()).unwrap();
-                }
-            }
-            KeyNode::Value(_, _) => error_exit(Message::UnknownError),
-            KeyNode::Nil => (),
-        }
-        match result.right_only_keys {
-            KeyNode::Node(_) => {
-                let mut keys = Vec::new();
-                result.right_only_keys.absolute_keys(&mut keys, None);
-                writeln!(handle, "\n{}:", Message::RightExtra).unwrap();
-                for key in keys {
-                    writeln!(handle, "{}", key.green().bold()).unwrap();
-                }
-            }
-            KeyNode::Value(_, _) => error_exit(Message::UnknownError),
-            KeyNode::Nil => (),
-        }
-    }
+    match display_output(mismatch) {
+        Ok(_) => (),
+        Err(err) => eprintln!("{}", err),
+    };
 }
 
-fn compare_jsons(a: &str, b: &str) -> Mismatch {
-    if let Ok(value1) = serde_json::from_str(a) {
-        if let Ok(value2) = serde_json::from_str(b) {
-            process::match_json(&value1, &value2)
-        } else {
-            error_exit(Message::JSON2);
-        }
-    } else {
-        error_exit(Message::JSON1);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use maplit::hashmap;
-    use serde_json::json;
-
-    #[test]
-    fn nested_diff() {
-        let data1 = r#"{
-            "a":"b", 
-            "b":{
-                "c":{
-                    "d":true,
-                    "e":5,
-                    "f":9,
-                    "h":{
-                        "i":true,
-                        "j":false
-                    }
-                }
-            }
-        }"#;
-        let data2 = r#"{
-            "a":"b",
-            "b":{
-                "c":{
-                    "d":true,
-                    "e":6,
-                    "g":0,
-                    "h":{
-                        "i":false,
-                        "k":false
-                    }
-                }
-            }
-        }"#;
-
-        let expected_left = KeyNode::Node(hashmap! {
-        "b".to_string() => KeyNode::Node(hashmap! {
-                "c".to_string() => KeyNode::Node(hashmap! {
-                        "f".to_string() => KeyNode::Nil,
-                        "h".to_string() => KeyNode::Node( hashmap! {
-                                "j".to_string() => KeyNode::Nil,
-                            }
-                        ),
-                }
-                ),
-            }),
-        });
-        let expected_right = KeyNode::Node(hashmap! {
-            "b".to_string() => KeyNode::Node(hashmap! {
-                    "c".to_string() => KeyNode::Node(hashmap! {
-                            "g".to_string() => KeyNode::Nil,
-                            "h".to_string() => KeyNode::Node(hashmap! {
-                                    "k".to_string() => KeyNode::Nil,
-                                }
-                            )
-                        }
-                    )
-                }
-            )
-        });
-        let expected_uneq = KeyNode::Node(hashmap! {
-            "b".to_string() => KeyNode::Node(hashmap! {
-                    "c".to_string() => KeyNode::Node(hashmap! {
-                            "e".to_string() => KeyNode::Value(json!(5), json!(6)),
-                            "h".to_string() => KeyNode::Node(hashmap! {
-                                    "i".to_string() => KeyNode::Value(json!(true), json!(false)),
-                                }
-                            )
-                        }
-                    )
-                }
-            )
-        });
-        let expected = Mismatch::new(expected_left, expected_right, expected_uneq);
-
-        let mismatch = compare_jsons(data1, data2);
-        assert_eq!(mismatch, expected, "Diff was incorrect.");
-    }
-
-    #[test]
-    fn no_diff() {
-        let data1 = r#"{
-            "a":"b", 
-            "b":{
-                "c":{
-                    "d":true,
-                    "e":5,
-                    "f":9,
-                    "h":{
-                        "i":true,
-                        "j":false
-                    }
-                }
-            }
-        }"#;
-        let data2 = r#"{
-            "a":"b", 
-            "b":{
-                "c":{
-                    "d":true,
-                    "e":5,
-                    "f":9,
-                    "h":{
-                        "i":true,
-                        "j":false
-                    }
-                }
-            }
-        }"#;
-
-        assert_eq!(
-            compare_jsons(data1, data2),
-            Mismatch::new(KeyNode::Nil, KeyNode::Nil, KeyNode::Nil)
-        );
-    }
-
-    #[test]
-    fn no_json() {
-        let data1 = r#"{}"#;
-        let data2 = r#"{}"#;
-
-        assert_eq!(
-            compare_jsons(data1, data2),
-            Mismatch::new(KeyNode::Nil, KeyNode::Nil, KeyNode::Nil)
-        );
-    }
+fn error_exit(message: Message) -> ! {
+    eprintln!("{}", message);
+    proc::exit(1);
 }


### PR DESCRIPTION
Hello,
Thank you for this crate. We have a requirement in one of our project where we could use this as a library dependency. I've moved the core functions and the related tests that you've written in your main.rs into a library so that we can use it from the https://crates.io. None of the core functionalities were altered, only a refactor to use this as a library.
Currently, we are using this in our cargo.toml as 
```
json_diff = { git = "https://github.com/nohupped/json-diff" }

```
It'd be great if you can consider reviewing this PR.

* Define `[lib]` and `[[bin]]` sections in the `Cargo.toml` file to keep this a binary, while also supporting to be a library
* Moved top level functions from `main.rs` to `lib.rs` and changed scope to pub so that this can be called from other crates.
* Moved the unit tests that were relevant to the moved functions into `lib.rs`
* To give the user a chance to handle the error instead of a panic from the library, changed the return type of `compare_jsons` and `display_output` functions to type `Result` and return error in favour of `unwrap()`, and made the changes in `main.rs` while calling these functions.
Fixes #1 
Thanks.